### PR TITLE
Removed hard-coded path of VTK_BINARY_DIR

### DIFF
--- a/Wrapping/Python/CMakeLists.txt
+++ b/Wrapping/Python/CMakeLists.txt
@@ -45,7 +45,7 @@ set(_vtkpy_modules
   # bug, the dependency wasn't being setup properly. Hence we directly depend on
   # the generated file. Once Ninja or Cmake is fixed, we can remove this file
   # depedency and leave the target dependecy.
-  ${CMAKE_BINARY_DIR}/VTK/Wrapping/Python/vtk_compile_complete
+  ${VTK_BINARY_DIR}/Wrapping/Python/vtk_compile_complete
   vtkpython_pyc
   )
 if (TARGET vtkWebPython)


### PR DESCRIPTION
Without this ParaView can't be built with Python support from another project that includes it from it's ```CMakeLists.txt``` with ```add_subdirectory(ParaView)```
