### PR TITLE
Reduce required CMake version to 3.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@
 #  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 #==========================================================================
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.3)
 
 project(ParaView)
 


### PR DESCRIPTION
Don't require the most resent version to give distributions
the chance to package ParaView.