### PR TITLE
Circumvent simplified widget

### DIFF
--- a/Qt/Widgets/pqDoubleLineEdit.cxx
+++ b/Qt/Widgets/pqDoubleLineEdit.cxx
@@ -263,15 +263,15 @@ void pqDoubleLineEdit::setUseGlobalPrecisionAndNotation(bool value)
 //-----------------------------------------------------------------------------
 void pqDoubleLineEdit::paintEvent(QPaintEvent* evt)
 {
-  auto& internals = (*this->Internals);
-  if (internals.useFullPrecision(this))
-  {
+//   auto& internals = (*this->Internals);
+//   if (internals.useFullPrecision(this))
+//   {
     this->Superclass::paintEvent(evt);
-  }
-  else
-  {
-    internals.renderSimplified(this);
-  }
+//   }
+//   else
+//   {
+//     internals.renderSimplified(this);
+//   }
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Hi everyone,
this PR is related to a node editor prototype for ParaView: https://github.com/JonasLukasczyk/paraview-node-editor

The node editor uses the existing classes of PV to create property widgets for filters and then shows those in the nodes. However, pqDoubleLineEdit widgets are not shown unless they are active or hovered over. I tracked the problem down to the explicit render call in line 125 of pqDoubleLineEdit.cxx of an internal widget that is used to show a simplified version of the float value if the element is not in focus (I guess). However, this mechanism should be more abstract like in the other widgets so that they automatically work with the Qt Canvas-Framework.

This PR currently just circumvents the render call of the simplified widget. It is supposed to get a discussion started on how to solve this issue.

Best
Jonas

@mwestphal 